### PR TITLE
Fix error handling in the FS put method

### DIFF
--- a/pepic/storage/fs.go
+++ b/pepic/storage/fs.go
@@ -20,15 +20,19 @@ func NewFileSystemBackend(dir string) *FileSystemBackend {
 func (fs *FileSystemBackend) PutObject(objectName string, data []byte) (string, error) {
 	fullPath := path.Join(fs.dir, objectName)
 
-	os.MkdirAll(path.Dir(fullPath), os.ModePerm)
+	if err := os.MkdirAll(path.Dir(fullPath), os.ModePerm); err != nil {
+		return "", err
+	}
+
 	dst, err := os.Create(fullPath)
+
 	if err != nil {
 		return "", err
 	}
+
 	defer dst.Close()
 
-	_, err = dst.Write(data)
-	if err != nil {
+	if _, err = dst.Write(data); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Handles permission denied error correctly and stops the execution so it looks like this:

`mkdir /app/uploads/orig: permission denied`

Instead of being overwritten by failing `os.Create` with `open /app/uploads/orig/7c9/f86/aa1/d79a9b6ba29ff68efe31c1bcf3c99db157af4511b8737da3d613c3b.png: no such file or directory`.